### PR TITLE
Client Wrapper changes and tests

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -17,58 +17,21 @@ export class ClientWrapper {
     this.client = new clientConstructor(auth.get('apiKey').toString());
   }
 
-  public async getPersonByEmail(email: string): Promise<PersonRequest> {
-    return new Promise((resolve, reject) => {
-      this.client.People.list({
-        email_addresses: [email],
-      }).then((person) => {
-        if (!person[0]) {
-          reject('Person not found');
-        }
-
-        resolve(person[0]);
-      }).catch((error) => {
-        reject(error);
-      });
+  public async findPersonByEmail(email: string) {
+    return this.client.People.list({
+      email_addresses: [email],
     });
   }
 
-  public async createOrUpdatePerson(person: PersonRequest): Promise<Object> {
-    return new Promise(async (resolve, reject) => {
-
-      try {
-        const existingPerson: PersonRequest = await this.getPersonByEmail(person['email_address']);
-
-        this.client.People.update(existingPerson['id'], existingPerson).then((response) => {
-          resolve(response);
-        }).catch((error) => {
-          reject(error);
-        });
-      } catch (e) {
-        if (e === 'Person not found') {
-          this.client.People.create(person).then((response) => {
-            resolve(response);
-          }).catch((error) => {
-            reject(error);
-          });
-        }
-      }
-
-    });
+  public async createPerson(person: PersonRequest) {
+    return this.client.People.create(person);
   }
 
-  public async deletePersonByEmail(email: string): Promise<Object> {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const person = await this.getPersonByEmail(email);
-        this.client.People.delete(person['id']).then((response) => {
-          resolve(response);
-        }).catch((error) => {
-          reject(error);
-        });
-      } catch (e) {
-        reject(e);
-      }
-    });
+  public async updatePerson(id: number, person: PersonRequest) {
+    return this.client.People.update(id, person);
+  }
+
+  public async deletePerson(id: number) {
+    return this.client.People.delete(id);
   }
 }

--- a/src/steps/person-create-or-update.ts
+++ b/src/steps/person-create-or-update.ts
@@ -20,16 +20,19 @@ export class CreateOrUpdatePersonStep extends BaseStep implements StepInterface 
     const person: Object = stepData.person;
 
     try {
-      const data = await this.client.createOrUpdatePerson(person);
-      if (data && data.id) {
-        return this.pass('Successfully created or updated SalesLoft person %s', [
-          person['email_address'],
-        ]);
+      const existingPerson = (await this.client.findPersonByEmail(person['email_address']))[0];
+
+      if (!existingPerson) {
+        await this.client.createPerson(person);
       } else {
-        return this.fail('Unable to create or update SalesLoft person');
+        await this.client.updatePerson(existingPerson['id'], person);
       }
+
+      return this.pass('Successfully created or updated SalesLoft person %s.', [
+        person['email_address'],
+      ]);
     } catch (e) {
-      return this.error('There was an error creating or updating the person in SalesLoft: %s', [
+      return this.error('There was an error creating or updating the person in SalesLoft: %s.', [
         e.toString(),
       ]);
     }

--- a/src/steps/person-delete.ts
+++ b/src/steps/person-delete.ts
@@ -20,12 +20,20 @@ export class DeletePersonStep extends BaseStep implements StepInterface {
     const email: Object = stepData.email;
 
     try {
-      await this.client.deletePersonByEmail(email);
-      return this.pass('Successfully deleted SalesLoft person %s', [
+      const person = (await this.client.findPersonByEmail(email))[0];
+
+      if (!person) {
+        return this.error('Person %s not found', [
+          email,
+        ]);
+      }
+
+      await this.client.deletePerson(person['id']);
+      return this.pass('Successfully deleted SalesLoft person %s.', [
         email,
       ]);
     } catch (e) {
-      return this.error('There was an error deleting the person in SalesLoft: %s', [
+      return this.error('There was an error deleting the person in SalesLoft: %s.', [
         e.toString(),
       ]);
     }

--- a/src/steps/person-field-equals.ts
+++ b/src/steps/person-field-equals.ts
@@ -30,10 +30,16 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
     const field = stepData.field;
 
     try {
-      const contact = await this.client.getPersonByEmail(email);
+      const person = (await this.client.findPersonByEmail(email))[0];
+
+      if (!person) {
+        return this.error('Person %s not found.', [
+          email,
+        ]);
+      }
 
       // tslint:disable-next-line:triple-equals
-      if (contact[field] == expectation) {
+      if (person[field] == expectation) {
         return this.pass('The %s field was %s, as expected.', [
           field,
           expectation,
@@ -42,11 +48,11 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
         return this.fail('Expected %s to be %s, but it was actually %s.', [
           field,
           expectation,
-          contact[field],
+          person[field],
         ]);
       }
     } catch (e) {
-      return this.error('There was an error loading contacts from Hubspot: %s', [e.toString()]);
+      return this.error('There was an error loading contacts from SalesLoft: %s.', [e.toString()]);
     }
   }
 

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -1,43 +1,94 @@
-// import * as chai from 'chai';
-// import { default as sinon } from 'ts-sinon';
-// import * as sinonChai from 'sinon-chai';
-// import 'mocha';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
 
-// import { ClientWrapper } from '../../src/client/client-wrapper';
-// import { Metadata } from 'grpc';
+import { ClientWrapper } from '../../src/client/client-wrapper';
+import { Metadata } from 'grpc';
+import { PersonRequest } from 'salesloft/dist/resources/People';
 
-// chai.use(sinonChai);
+chai.use(sinonChai);
 
-// describe('ClientWrapper', () => {
-//   const expect = chai.expect;
-//   let needleConstructorStub: any;
-//   let metadata: Metadata;
-//   let clientWrapperUnderTest: ClientWrapper;
+describe('ClientWrapper', () => {
+  const expect = chai.expect;
+  let salesloftClientStub: any;
+  let salesloftConstructorStub: any;
+  let metadata: Metadata;
+  let clientWrapperUnderTest: ClientWrapper;
 
-//   beforeEach(() => {
-//     needleConstructorStub = sinon.stub();
-//     needleConstructorStub.defaults = sinon.stub();
-//   });
+  beforeEach(() => {
+    salesloftClientStub = {
+      People: {
+        list: sinon.spy(),
+        create: sinon.spy(),
+        update: sinon.spy(),
+        delete: sinon.spy(),
+      },
+    };
+    salesloftConstructorStub = sinon.stub();
+    salesloftConstructorStub.returns(salesloftClientStub);
+  });
 
-//   it('authenticates', () => {
-//     // Construct grpc metadata and assert the client was authenticated.
-//     const expectedCallArgs = { user_agent: 'Some/UserAgent String' };
-//     metadata = new Metadata();
-//     metadata.add('userAgent', expectedCallArgs.user_agent);
+  describe('constructor', () => {
+    it('should authenticate', () => {
+      const expectedArgs = 'apiKey';
+      metadata = new Metadata();
+      metadata.add('apikey', expectedArgs);
 
-//     // Assert that the underlying API client was authenticated correctly.
-//     clientWrapperUnderTest = new ClientWrapper(metadata, needleConstructorStub);
-//     expect(needleConstructorStub.defaults).to.have.been.calledWith(expectedCallArgs);
-//   });
+      clientWrapperUnderTest = new ClientWrapper(metadata, salesloftConstructorStub);
+      expect(salesloftConstructorStub).to.have.been.calledWith(expectedArgs);
+    });
+  });
 
-//   it('getUserByEmail', () => {
-//     const expectedEmail = 'test@example.com';
-//     clientWrapperUnderTest = new ClientWrapper(metadata, needleConstructorStub);
-//     clientWrapperUnderTest.getUserByEmail(expectedEmail);
+  describe('findPersonByEmail', () => {
+    it('should call with expectedArgs', async () => {
+      const expectedArgs = {
+        email_addresses: ['salesloft@test.com'],
+      };
 
-//     expect(needleConstructorStub).to.have.been.calledWith(
-//       `https://jsonplaceholder.typicode.com/users?email=${expectedEmail}`,
-//     );
-//   });
+      clientWrapperUnderTest = new ClientWrapper(new Metadata(), salesloftConstructorStub);
+      await clientWrapperUnderTest.findPersonByEmail('salesloft@test.com');
+      expect(salesloftClientStub.People.list).to.have.been.calledWith(expectedArgs);
+    });
+  });
 
-// });
+  describe('createPerson', () => {
+    it('should call with expectedArgs', async () => {
+      const expectedArgs: PersonRequest = {
+        email_address: 'salesloft@test.com',
+        last_name: 'Test',
+        first_name: 'Unit',
+      };
+
+      clientWrapperUnderTest = new ClientWrapper(new Metadata(), salesloftConstructorStub);
+      await clientWrapperUnderTest.createPerson(expectedArgs);
+      expect(salesloftClientStub.People.create).to.have.been.calledWith(expectedArgs);
+    });
+  });
+
+  describe('updatePerson', () => {
+    it('should call with expectedArgs', async () => {
+      const expectedArgs: any = {
+        id: 1,
+        email_address: 'salesloft@test.com',
+        last_name: 'Test',
+        first_name: 'Unit',
+      };
+
+      clientWrapperUnderTest = new ClientWrapper(new Metadata(), salesloftConstructorStub);
+      await clientWrapperUnderTest.updatePerson(expectedArgs['id'], expectedArgs);
+      expect(salesloftClientStub.People.update).to.have.been.calledWith(
+          expectedArgs['id'], expectedArgs);
+    });
+  });
+
+  describe('deletePerson', () => {
+    it('should call with expectedArgs', async () => {
+      const expectedArgs: number = 1;
+
+      clientWrapperUnderTest = new ClientWrapper(new Metadata(), salesloftConstructorStub);
+      await clientWrapperUnderTest.deletePerson(expectedArgs);
+      expect(salesloftClientStub.People.delete).to.have.been.calledWith(expectedArgs);
+    });
+  });
+});


### PR DESCRIPTION
# Notes
1. Removed logic from `client-wrapper` to change it's implementation to **only** wrap the `salesloft package`
2. Added unit tests. `client-wrapper` now up to 100%