### PR TITLE
Fixed steps from returning invalid pass/fail message because the oper…

### DIFF
--- a/src/steps/person-field-equals.ts
+++ b/src/steps/person-field-equals.ts
@@ -56,9 +56,9 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
 
       // tslint:disable-next-line:triple-equals
       if (actual == expectation) {
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectation]);
+        return this.pass(this.operatorSuccessMessages[operator], [field, expectation]);
       } else {
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectation,
           person[field],


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)