### PR TITLE
Fixed SalesLoft from not calling the compare function

### DIFF
--- a/src/steps/person-field-equals.ts
+++ b/src/steps/person-field-equals.ts
@@ -55,7 +55,7 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
       }
 
       // tslint:disable-next-line:triple-equals
-      if (actual == expectation) {
+      if (this.compare(operator, actual, expectation)) {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectation]);
       } else {
         return this.fail(this.operatorFailMessages[operator], [


### PR DESCRIPTION
This should fix all `smooth operator` "is not working". The `compare` function was not called