### PR TITLE
Minor fixes to Person check step

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-ts": "tsc",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "start": "check-engine package.json && node -r ts-node/register src/core/grpc-server.ts",
-    "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts",
+    "test": "nyc mocha -r ts-node/register test/*.ts test/**/*.ts test/**/**/*.ts",
     "version": "crank cog:readme automatoninc/salesloft && git add README.md"
   },
   "nyc": {

--- a/src/steps/person/person-field-equals.ts
+++ b/src/steps/person/person-field-equals.ts
@@ -9,7 +9,7 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check a field on a SalesLoft Person';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_-]+) field on salesloft person (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectation>.+)';
+  protected stepExpression: string = 'the (?<field>[a-zA-Z0-9_- ]+) field on salesloft person (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectation>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',
@@ -46,13 +46,7 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
         ]);
       }
 
-      const actual = person[field] === undefined ? person['custom_fields'][field] : person[field];
-
-      if (!actual) {
-        return this.fail('The %s field was not found', [
-          field,
-        ]);
-      }
+      const actual = (person[field] === undefined ? person['custom_fields'][field] : person[field]) || null;
 
       // tslint:disable-next-line:triple-equals
       if (this.compare(operator, actual, expectation)) {
@@ -61,7 +55,7 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
         return this.fail(this.operatorFailMessages[operator], [
           field,
           expectation,
-          person[field],
+          actual,
         ]);
       }
     } catch (e) {

--- a/test/steps/person/person-field-equals.ts
+++ b/test/steps/person/person-field-equals.ts
@@ -27,7 +27,7 @@ describe('PersonFieldEquals', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('PersonFieldEqualsStep');
       expect(stepDef.getName()).to.equal('Check a field on a SalesLoft Person');
-      expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_-]+) field on salesloft person (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectation>.+)');
+      expect(stepDef.getExpression()).to.equal('the (?<field>[a-zA-Z0-9_- ]+) field on salesloft person (?<email>.+) should (?<operator>be less than|be greater than|be|contain|not be|not contain) (?<expectation>.+)');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 


### PR DESCRIPTION
- Improves failure message when custom field is null/empty (Closes #30)
- Fixes expression to allow custom fields containing spaces (Closes #29)