### PR TITLE
Applied fails vs errors changes to salesloft

### DIFF
--- a/src/steps/person/person-field-equals.ts
+++ b/src/steps/person/person-field-equals.ts
@@ -65,7 +65,7 @@ export class PersonFieldEqualsStep extends BaseStep implements StepInterface {
       const person = (await this.client.findPersonByEmail(email))[0];
 
       if (!person) {
-        return this.error('Person %s not found.', [
+        return this.fail('Person %s not found.', [
           email,
         ]);
       }


### PR DESCRIPTION
Some messages that are an `Error` have been changed to `Fail`